### PR TITLE
Add UG ores and ore grounds to forge tags

### DIFF
--- a/src/generated/resources/.cache/cache
+++ b/src/generated/resources/.cache/cache
@@ -536,6 +536,9 @@ bd992a6c7352517c7ddd4a916068b9ca3105a38d data/forge/tags/blocks/glass/colorless.
 bd992a6c7352517c7ddd4a916068b9ca3105a38d data/forge/tags/blocks/glass/silica.json
 f66692217e14affb604b531b8eacaa4e22655aec data/forge/tags/blocks/glass_panes.json
 f66692217e14affb604b531b8eacaa4e22655aec data/forge/tags/blocks/glass_panes/colorless.json
+6e428c51ca8e1db644cfa16d6291fac7e9d5f28c data/forge/tags/blocks/ore_bearing_ground/depthrock.json
+1586a56a74c88510d0155c038ac8ac8c2283e472 data/forge/tags/blocks/ore_bearing_ground/shiverstone.json
+efd30b3928c74cb42407982df4cf92fcaa9acb10 data/forge/tags/blocks/ore_bearing_ground/tremblecrust.json
 fb3511ed868251c31a57153dbc6596be78a75024 data/forge/tags/blocks/ore_rates/singular.json
 efc23852cc431b4dffb2d178a9ea57cc4f666df5 data/forge/tags/blocks/ore_rates/sparse.json
 fb3511ed868251c31a57153dbc6596be78a75024 data/forge/tags/blocks/ores.json
@@ -547,6 +550,9 @@ bfa732947582d40f94f38ae9f31470137ac7b12f data/forge/tags/blocks/ores/gold.json
 c1d6cf3d6813c2f3a82baa50d773505134185ade data/forge/tags/blocks/ores/iron.json
 2873f8076a224cd93b28d89dbc9015c890769fb9 data/forge/tags/blocks/ores/regalium.json
 02c3f292b0ea72b2bc192aad10c2634085a3c1d4 data/forge/tags/blocks/ores/utherium.json
+9ddfbb5dcf5da7a8e1dd658a02dfacb9c6c5cdef data/forge/tags/blocks/ores_in_ground/depthrock.json
+12b824ac1336743c5e05ee34f6a15ba87b1409b6 data/forge/tags/blocks/ores_in_ground/shiverstone.json
+d2a07d859980ea37a0cdae180942fa27433b9429 data/forge/tags/blocks/ores_in_ground/tremblecrust.json
 d004ec3b3367880a0cf2739ee47ad9dc91afc556 data/forge/tags/blocks/sand.json
 d004ec3b3367880a0cf2739ee47ad9dc91afc556 data/forge/tags/blocks/sand/colorless.json
 14067c5aef4c08ff14d0f163328d74ce1c5e634f data/forge/tags/blocks/stone.json

--- a/src/generated/resources/data/forge/tags/blocks/ore_bearing_ground/depthrock.json
+++ b/src/generated/resources/data/forge/tags/blocks/ore_bearing_ground/depthrock.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "undergarden:depthrock"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/blocks/ore_bearing_ground/shiverstone.json
+++ b/src/generated/resources/data/forge/tags/blocks/ore_bearing_ground/shiverstone.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "undergarden:shiverstone"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/blocks/ore_bearing_ground/tremblecrust.json
+++ b/src/generated/resources/data/forge/tags/blocks/ore_bearing_ground/tremblecrust.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "undergarden:tremblecrust"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/blocks/ores_in_ground/depthrock.json
+++ b/src/generated/resources/data/forge/tags/blocks/ores_in_ground/depthrock.json
@@ -1,0 +1,12 @@
+{
+  "replace": false,
+  "values": [
+    "undergarden:depthrock_coal_ore",
+    "undergarden:depthrock_iron_ore",
+    "undergarden:depthrock_diamond_ore",
+    "undergarden:depthrock_gold_ore",
+    "undergarden:depthrock_cloggrum_ore",
+    "undergarden:depthrock_utherium_ore",
+    "undergarden:depthrock_regalium_ore"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/blocks/ores_in_ground/shiverstone.json
+++ b/src/generated/resources/data/forge/tags/blocks/ores_in_ground/shiverstone.json
@@ -1,0 +1,12 @@
+{
+  "replace": false,
+  "values": [
+    "undergarden:shiverstone_coal_ore",
+    "undergarden:shiverstone_iron_ore",
+    "undergarden:shiverstone_diamond_ore",
+    "undergarden:shiverstone_froststeel_ore",
+    "undergarden:shiverstone_cloggrum_ore",
+    "undergarden:shiverstone_utherium_ore",
+    "undergarden:shiverstone_regalium_ore"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/blocks/ores_in_ground/tremblecrust.json
+++ b/src/generated/resources/data/forge/tags/blocks/ores_in_ground/tremblecrust.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "undergarden:tremblecrust_utherium_ore"
+  ]
+}

--- a/src/main/java/quek/undergarden/data/UGBlockTags.java
+++ b/src/main/java/quek/undergarden/data/UGBlockTags.java
@@ -47,6 +47,12 @@ public class UGBlockTags extends BlockTagsProvider {
         tag(UGTags.Blocks.STORAGE_BLOCKS_REGALIUM).add(UGBlocks.REGALIUM_BLOCK.get());
         tag(UGTags.Blocks.STORAGE_BLOCKS_RAW_CLOGGRUM).add(UGBlocks.RAW_CLOGGRUM_BLOCK.get());
         tag(UGTags.Blocks.STORAGE_BLOCKS_RAW_FROSTSTEEL).add(UGBlocks.RAW_FROSTSTEEL_BLOCK.get());
+        tag(UGTags.Blocks.DEPTHROCK_GROUND).add(UGBlocks.DEPTHROCK.get());
+        tag(UGTags.Blocks.DEPTHROCK_ORES).add(UGBlocks.DEPTHROCK_COAL_ORE.get(), UGBlocks.DEPTHROCK_IRON_ORE.get(), UGBlocks.DEPTHROCK_DIAMOND_ORE.get(), UGBlocks.DEPTHROCK_GOLD_ORE.get(), UGBlocks.DEPTHROCK_CLOGGRUM_ORE.get(), UGBlocks.DEPTHROCK_UTHERIUM_ORE.get(), UGBlocks.DEPTHROCK_REGALIUM_ORE.get());
+        tag(UGTags.Blocks.SHIVERSTONE_GROUND).add(UGBlocks.SHIVERSTONE.get());
+        tag(UGTags.Blocks.SHIVERSTONE_ORES).add(UGBlocks.SHIVERSTONE_COAL_ORE.get(), UGBlocks.SHIVERSTONE_IRON_ORE.get(), UGBlocks.SHIVERSTONE_DIAMOND_ORE.get(), UGBlocks.SHIVERSTONE_FROSTSTEEL_ORE.get(), UGBlocks.SHIVERSTONE_CLOGGRUM_ORE.get(), UGBlocks.SHIVERSTONE_UTHERIUM_ORE.get(), UGBlocks.SHIVERSTONE_REGALIUM_ORE.get());
+        tag(UGTags.Blocks.TREMBLECRUST_GROUND).add(UGBlocks.TREMBLECRUST.get());
+        tag(UGTags.Blocks.TREMBLECRUST_ORES).add(UGBlocks.TREMBLECRUST_UTHERIUM_ORE.get());
 
         //vanilla
         tag(BlockTags.PLANKS).add(UGBlocks.SMOGSTEM_PLANKS.get(), UGBlocks.WIGGLEWOOD_PLANKS.get(), UGBlocks.GRONGLE_PLANKS.get());

--- a/src/main/java/quek/undergarden/registry/UGTags.java
+++ b/src/main/java/quek/undergarden/registry/UGTags.java
@@ -75,6 +75,15 @@ public class UGTags {
         public static final TagKey<Block> STORAGE_BLOCKS_RAW_CLOGGRUM = forgeTag("storage_blocks/raw_cloggrum");
         public static final TagKey<Block> STORAGE_BLOCKS_RAW_FROSTSTEEL = forgeTag("storage_blocks/raw_froststeel");
 
+        public static final TagKey<Block> DEPTHROCK_GROUND = forgeTag("ore_bearing_ground/depthrock");
+        public static final TagKey<Block> DEPTHROCK_ORES = forgeTag("ores_in_ground/depthrock");
+
+        public static final TagKey<Block> SHIVERSTONE_GROUND = forgeTag("ore_bearing_ground/shiverstone");
+        public static final TagKey<Block> SHIVERSTONE_ORES = forgeTag("ores_in_ground/shiverstone");
+
+        public static final TagKey<Block> TREMBLECRUST_GROUND = forgeTag("ore_bearing_ground/tremblecrust");
+        public static final TagKey<Block> TREMBLECRUST_ORES = forgeTag("ores_in_ground/tremblecrust");
+
         private static TagKey<Block> tag(String name) {
             return BlockTags.create(new ResourceLocation(Undergarden.MODID, name));
         }


### PR DESCRIPTION
Adds 6 new tags, all relating to the forge ores_in_ground and ore_bearing_ground tags. Adding these allows any mod that relies on this category of tags to utilize your ores/grounds. A good example of this is the ore magnet from Twilight Forest. By adding these, the ore magnet will now properly pull up ores and leave the correct ground behind in its place. 

Please let me know if I missed any blocks, I'm fairly sure I got them all