### PR TITLE
Add Virulent Cauldron functionality

### DIFF
--- a/src/main/java/quek/undergarden/Undergarden.java
+++ b/src/main/java/quek/undergarden/Undergarden.java
@@ -89,6 +89,7 @@ public class Undergarden {
 			UGEntityTypes.spawnPlacements();
 			UGCriteria.register();
 			UGBiomes.toDictionary();
+			UGCauldronInteraction.register();
 
 			DispenseItemBehavior bucketBehavior = new DefaultDispenseItemBehavior() {
 				private final DefaultDispenseItemBehavior defaultBehavior = new DefaultDispenseItemBehavior();

--- a/src/main/java/quek/undergarden/Undergarden.java
+++ b/src/main/java/quek/undergarden/Undergarden.java
@@ -89,7 +89,7 @@ public class Undergarden {
 			UGEntityTypes.spawnPlacements();
 			UGCriteria.register();
 			UGBiomes.toDictionary();
-			UGCauldronInteraction.register();
+			UGCauldronInteractions.register();
 
 			DispenseItemBehavior bucketBehavior = new DefaultDispenseItemBehavior() {
 				private final DefaultDispenseItemBehavior defaultBehavior = new DefaultDispenseItemBehavior();

--- a/src/main/java/quek/undergarden/block/VirulentMixCauldronBlock.java
+++ b/src/main/java/quek/undergarden/block/VirulentMixCauldronBlock.java
@@ -13,7 +13,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.AbstractCauldronBlock;
 import net.minecraft.world.level.block.state.BlockState;
 
-import quek.undergarden.registry.UGCauldronInteraction;
+import quek.undergarden.registry.UGCauldronInteractions;
 import quek.undergarden.registry.UGEffects;
 import quek.undergarden.registry.UGSoundEvents;
 import quek.undergarden.registry.UGTags;
@@ -23,7 +23,7 @@ import java.util.Random;
 public class VirulentMixCauldronBlock extends AbstractCauldronBlock {
 
     public VirulentMixCauldronBlock(Properties properties) {
-        super(properties, UGCauldronInteraction.VIRULENT_MIX);
+        super(properties, UGCauldronInteractions.VIRULENT_MIX);
     }
 
     @Override

--- a/src/main/java/quek/undergarden/block/VirulentMixCauldronBlock.java
+++ b/src/main/java/quek/undergarden/block/VirulentMixCauldronBlock.java
@@ -1,0 +1,64 @@
+package quek.undergarden.block;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.effect.MobEffects;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.AbstractCauldronBlock;
+import net.minecraft.world.level.block.state.BlockState;
+
+import quek.undergarden.registry.UGCauldronInteraction;
+import quek.undergarden.registry.UGEffects;
+import quek.undergarden.registry.UGSoundEvents;
+import quek.undergarden.registry.UGTags;
+
+import java.util.Random;
+
+public class VirulentMixCauldronBlock extends AbstractCauldronBlock {
+
+    public VirulentMixCauldronBlock(Properties properties) {
+        super(properties, UGCauldronInteraction.VIRULENT_MIX);
+    }
+
+    @Override
+    public boolean isFull(BlockState state) {
+        return true;
+    }
+
+    @Override
+    protected double getContentHeight(BlockState state) {
+        return 0.9375D;
+    }
+
+    @Override
+    public int getAnalogOutputSignal(BlockState state, Level level, BlockPos pos) {
+        return 3;
+    }
+
+    @Override
+    public void entityInside(BlockState state, Level world, BlockPos pos, Entity entity) {
+        if(entity.isAlive() && entity instanceof LivingEntity livingEntity) {
+            if(livingEntity.getType().is(UGTags.Entities.IMMUNE_TO_VIRULENT_MIX)) {}
+            else if(livingEntity.hasEffect(UGEffects.VIRULENT_RESISTANCE.get())) {}
+            else livingEntity.addEffect(new MobEffectInstance(MobEffects.POISON, 200, 0));
+        }
+    }
+
+    @Override
+    public void animateTick(BlockState state, Level world, BlockPos pos, Random rand) {
+        if (rand.nextInt(200) == 0) {
+            world.playLocalSound(pos.getX(), pos.getY(), pos.getZ(), UGSoundEvents.VIRULENT_BUBBLE.get(), SoundSource.BLOCKS, 1.0F, 1.0F, false);
+        }
+    }
+
+    @Override
+    public ItemStack getCloneItemStack(BlockGetter level, BlockPos pos, BlockState state) {
+        return new ItemStack(Items.CAULDRON);
+    }
+}

--- a/src/main/java/quek/undergarden/registry/UGBlocks.java
+++ b/src/main/java/quek/undergarden/registry/UGBlocks.java
@@ -263,6 +263,8 @@ public class UGBlocks {
     public static final RegistryObject<LiquidBlock> VIRULENT_MIX = BLOCKS.register("virulent_mix", () -> new VirulentMixBlock(
             UGFluids.VIRULENT_MIX_SOURCE, BlockBehaviour.Properties.of(Material.WATER)));
 
+    public static final RegistryObject<Block> VIRULENT_MIX_CAULDRON = BLOCKS.register("virulent_mix_cauldron", () -> new VirulentMixCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON).lightLevel((state) -> 10).randomTicks()));
+
     private static <T extends Block> RegistryObject<T> baseRegister(String name, Supplier<? extends T> block, Function<RegistryObject<T>, Supplier<? extends Item>> item) {
         RegistryObject<T> register = BLOCKS.register(name, block);
         UGItems.ITEMS.register(name, item.apply(register));

--- a/src/main/java/quek/undergarden/registry/UGCauldronInteraction.java
+++ b/src/main/java/quek/undergarden/registry/UGCauldronInteraction.java
@@ -1,0 +1,30 @@
+package quek.undergarden.registry;
+
+import net.minecraft.core.cauldron.CauldronInteraction;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+
+import java.util.Map;
+public interface UGCauldronInteraction extends CauldronInteraction {
+
+    CauldronInteraction FILL_VIRULENT_MIX = (state, world, pos, player, hand, stack) ->
+            CauldronInteraction.emptyBucket(world, pos, player, hand, stack, UGBlocks.VIRULENT_MIX_CAULDRON.get().defaultBlockState(), UGSoundEvents.BUCKET_EMPTY_VIRULENT.get());
+
+    CauldronInteraction EMPTY_VIRULENT_MIX = (state, world, pos, player, hand, stack) ->
+            CauldronInteraction.fillBucket(state, world, pos, player, hand, stack, new ItemStack(UGItems.VIRULENT_MIX_BUCKET.get()), blockState -> true, UGSoundEvents.BUCKET_FILL_VIRULENT.get());
+
+    Map<Item, CauldronInteraction> VIRULENT_MIX = CauldronInteraction.newInteractionMap();
+
+    static void register() {
+        EMPTY.put(UGItems.VIRULENT_MIX_BUCKET.get(), FILL_VIRULENT_MIX);
+        WATER.put(UGItems.VIRULENT_MIX_BUCKET.get(), FILL_VIRULENT_MIX);
+        LAVA.put(UGItems.VIRULENT_MIX_BUCKET.get(), FILL_VIRULENT_MIX);
+        POWDER_SNOW.put(UGItems.VIRULENT_MIX_BUCKET.get(), FILL_VIRULENT_MIX);
+        VIRULENT_MIX.put(UGItems.VIRULENT_MIX_BUCKET.get(), FILL_VIRULENT_MIX);
+
+        VIRULENT_MIX.put(Items.BUCKET, EMPTY_VIRULENT_MIX);
+
+        CauldronInteraction.addDefaultInteractions(VIRULENT_MIX);
+    }
+}

--- a/src/main/java/quek/undergarden/registry/UGCauldronInteractions.java
+++ b/src/main/java/quek/undergarden/registry/UGCauldronInteractions.java
@@ -6,7 +6,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 
 import java.util.Map;
-public interface UGCauldronInteraction extends CauldronInteraction {
+public interface UGCauldronInteractions extends CauldronInteraction {
 
     CauldronInteraction FILL_VIRULENT_MIX = (state, world, pos, player, hand, stack) ->
             CauldronInteraction.emptyBucket(world, pos, player, hand, stack, UGBlocks.VIRULENT_MIX_CAULDRON.get().defaultBlockState(), UGSoundEvents.BUCKET_EMPTY_VIRULENT.get());

--- a/src/main/resources/assets/undergarden/blockstates/virulent_mix_cauldron.json
+++ b/src/main/resources/assets/undergarden/blockstates/virulent_mix_cauldron.json
@@ -1,0 +1,7 @@
+{
+  "variants": {
+    "": {
+      "model": "undergarden:block/virulent_mix_cauldron"
+    }
+  }
+}

--- a/src/main/resources/assets/undergarden/models/block/virulent_mix_cauldron.json
+++ b/src/main/resources/assets/undergarden/models/block/virulent_mix_cauldron.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:block/template_cauldron_full",
+  "textures": {
+    "content": "undergarden:fluid/virulent_mix_still"
+  }
+}


### PR DESCRIPTION
Works as expected, copies poison properties from the fluid as well as animated tick sounds. Only thing that might be missing is pointed dripstone functionality.

UGCauldronInteraction.java allows for the ability to easily implement other cauldron fluids and interactions if the mod ever needs it.